### PR TITLE
Lower python minimum version for compatibility with downstream packages

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,18 +11,18 @@ source:
   sha256: bab2dc2aeb9560264791298f1d206b78fd9b345cecdd500b34f469d367765158
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   noarch: python
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python >=2.7
   run:
     - joblib
     - lasagne
-    - python >=3.6
+    - python >=2.7
     - scikit-learn <0.20
     - tabulate
     - theano


### PR DESCRIPTION
This package is quite old (2014) and not maintained anymore. To also get [packages onto conda built around the same time](https://bitbucket.org/gusphdproj/deeparg-ss/src/master/) but written in python 2.7, I'm lowering the minimum version.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
